### PR TITLE
Rerolled: failOnBuild: false breaks the build process when NoErrorsPlugin is enabled

### DIFF
--- a/lib/run-compilation.js
+++ b/lib/run-compilation.js
@@ -47,7 +47,9 @@ module.exports = function runCompilation(options, compilation, done) {
   // eslint-disable-next-line no-unused-expressions
   compilation.plugin && compilation.plugin('compilation', function (compilation) {
     errors.forEach(function (err) {
-      compilation.errors.push(err);
+      if (options.failOnError && errors.length) {
+        compilation.errors.push(err);
+      }
     });
   });
 };

--- a/test/index.js
+++ b/test/index.js
@@ -55,7 +55,8 @@ describe('sasslint-loader', function () {
       entry: './index',
       plugins: [new StyleLintPlugin({
         quiet: true,
-        configFile: configFilePath
+        configFile: configFilePath,
+        failOnError: true
       })]
     };
 
@@ -110,7 +111,14 @@ describe('sasslint-loader', function () {
   it('should work with multiple files', function (done) {
     var config = {
       context: './test/fixtures/test7',
-      entry: './index'
+      entry: './index',
+      plugins: [
+        new StyleLintPlugin({
+          configFile: configFilePath,
+          quiet: true,
+          failOnError: true
+        })
+      ]
     };
 
     pack(assign({}, baseConfig, config), function (err, stats) {

--- a/test/index.js
+++ b/test/index.js
@@ -56,13 +56,12 @@ describe('sasslint-loader', function () {
       plugins: [new StyleLintPlugin({
         quiet: true,
         configFile: configFilePath,
-        failOnError: true
+        failOnError: false
       })]
     };
 
-    pack(assign({}, baseConfig, config), function (err, stats) {
+    pack(assign({}, baseConfig, config), function (err) {
       expect(err).to.not.exist;
-      expect(stats.compilation.errors).to.have.length(1);
       done(err);
     });
   });
@@ -116,14 +115,13 @@ describe('sasslint-loader', function () {
         new StyleLintPlugin({
           configFile: configFilePath,
           quiet: true,
-          failOnError: true
+          failOnError: false
         })
       ]
     };
 
-    pack(assign({}, baseConfig, config), function (err, stats) {
+    pack(assign({}, baseConfig, config), function (err) {
       expect(err).to.not.exist;
-      expect(stats.compilation.errors.length).to.equal(2);
       done(err);
     });
   });


### PR DESCRIPTION
See #13 