### PR TITLE
More minor code tweaks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,4 +13,4 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.md]
-insert_final_newline = false
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/vieron/stylelint-webpack-plugin.svg?branch=master)](https://travis-ci.org/vieron/stylelint-webpack-plugin)
 [![Coverage Status](https://coveralls.io/repos/github/vieron/stylelint-webpack-plugin/badge.svg?branch=master)](https://coveralls.io/github/vieron/stylelint-webpack-plugin?branch=master)
 [![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/sindresorhus/xo)
+[![Gitter](https://badges.gitter.im/stylelint-webpack-plugin/Lobby.svg)](https://gitter.im/stylelint-webpack-plugin/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 ### Why you might want to use this plugin instead of [stylelint-loader](https://github.com/adrianhall/stylelint-loader)
 
@@ -23,7 +24,6 @@ In your webpack configuration
 
 ```js
 var StyleLintPlugin = require('stylelint-webpack-plugin');
-
 
 module.exports = {
   // ...

--- a/index.js
+++ b/index.js
@@ -20,7 +20,6 @@ function apply(options, compiler) {
     // Default Glob is any directory level of scss and/or sass file,
     // under webpack's context and specificity changed via globbing patterns
     files: arrify(options.files || '**/*.s?(c|a)ss').map(function (file) {
-      // TODO: make it work with arrays
       return path.join(context, '/', file);
     }),
     context: context
@@ -36,7 +35,7 @@ function apply(options, compiler) {
  * Pass options to the plugin that get checked and updated before running
  * ref: https://webpack.github.io/docs/plugins.html#the-compiler-instance
  * @param options - from webpack config, see defaults in `apply` function.
- * @returns object with the bound apply function
+ * @return {Object} the bound apply function
  */
 module.exports = function stylelintWebpackPlugin(options) {
   return {

--- a/test/index.js
+++ b/test/index.js
@@ -6,9 +6,7 @@ var assign = require('object-assign');
 var webpack = require('webpack');
 var MemoryFileSystem = require('memory-fs');
 
-// _dirname is the test directory
 var StyleLintPlugin = require(getPath('../index'));
-
 var outputFileSystem = new MemoryFileSystem();
 
 var configFilePath = getPath('./.stylelintrc');
@@ -25,16 +23,14 @@ var baseConfig = {
   ]
 };
 
-/**
- * This is the basic in-memory compiler
- */
+// This is the basic in-memory compiler
 function pack(testConfig, callback) {
   var compiler = webpack(testConfig);
   compiler.outputFileSystem = outputFileSystem;
   compiler.run(callback);
 }
 
-describe('sasslint-loader', function () {
+describe('stylelint-webpack-plugin', function () {
   it('works with a simple file', function (done) {
     var config = {
       context: './test/fixtures/test1',
@@ -53,10 +49,12 @@ describe('sasslint-loader', function () {
     var config = {
       context: './test/fixtures/test3',
       entry: './index',
-      plugins: [new StyleLintPlugin({
-        quiet: true,
-        configFile: configFilePath
-      })]
+      plugins: [
+        new StyleLintPlugin({
+          quiet: true,
+          configFile: configFilePath
+        })
+      ]
     };
 
     pack(assign({}, baseConfig, config), function (err, stats) {
@@ -102,12 +100,12 @@ describe('sasslint-loader', function () {
 
     pack(assign({}, baseConfig, config), function (err, stats) {
       expect(err).to.not.exist;
-      expect(stats.compilation.errors.length).to.equal(0);
+      expect(stats.compilation.errors).to.have.length(0);
       done(err);
     });
   });
 
-  it('should work with multiple files', function (done) {
+  it('works with multiple source files', function (done) {
     var config = {
       context: './test/fixtures/test7',
       entry: './index'
@@ -115,7 +113,7 @@ describe('sasslint-loader', function () {
 
     pack(assign({}, baseConfig, config), function (err, stats) {
       expect(err).to.not.exist;
-      expect(stats.compilation.errors.length).to.equal(2);
+      expect(stats.compilation.errors).to.have.length(2);
       done(err);
     });
   });


### PR DESCRIPTION
- consistent tense in test suite
- corrected editorconfig for markdown files
- use `.have.length` assertion