### PR TITLE
Remove "inherits from webpack" from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ module.exports = {
   plugins: [
     new StyleLintPlugin({
       configFile: '.stylelintrc',
-      context: 'inherits from webpack',
       files: '**/*.s?(a|c)ss',
       failOnError: false,
     })

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ module.exports = {
   plugins: [
     new StyleLintPlugin({
       configFile: '.stylelintrc',
+      context: /* inherits from webpack so leave undefined unless you need to change it */,
       files: '**/*.s?(a|c)ss',
       failOnError: false,
     })


### PR DESCRIPTION
See https://github.com/vieron/stylelint-webpack-plugin/issues/7#issuecomment-247270888

Resolves #7.